### PR TITLE
cmd is not supported on OSX and actually causes an error on Solaris:

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function childrenOfPid( pid, callback) {
     pid = pid.toString()
   
   es.connect(
-    spawn('ps', ['-A', '-o', 'ppid,pid,cmd']).stdout,
+    spawn('ps', ['-A', '-o', 'ppid,pid']).stdout,
     es.split(),
     es.map(function (line, cb) { //this could parse alot of unix command output
       var columns = line.trim().split(/\s+/)


### PR DESCRIPTION
```
$ ps -A -o ppid,pid,cmd
ps: unknown output format: -o cmd
usage: ps [ -aAdefHlcjLPyZ ] [ -o format ] [ -t termlist ]
        [ -u userlist ] [ -U userlist ] [ -G grouplist ]
        [ -p proclist ] [ -g pgrplist ] [ -s sidlist ] [ -z zonelist ] [-h lgrplist]
  'format' is one or more of:
        user ruser group rgroup uid ruid gid rgid pid ppid pgid sid taskid ctid
        pri opri pcpu pmem vsz rss osz nice class time etime stime zone zoneid
        f s c lwp nlwp psr tty addr wchan fname comm args projid project pset lgrp
```
