### PR TITLE
Correct SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "event-stream": "~3.3.0"
   },
   "author": "Charlie Robbins",
+  "license": "MIT",
   "directories": {
     "test": "test"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ps-tree",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Get all children of a pid",
   "homepage": "http://github.com/indexzero/ps-tree",
   "repository": {


### PR DESCRIPTION
This lets tools like `npm` or `nlf` report the license for this package.

See:
- https://docs.npmjs.com/files/package.json#license
- https://spdx.org/licenses/