### PR TITLE
Win32 platform support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,15 @@ node_js:
   - "0.10"
   - "0.12"
   - "4.0"
+  - "5.0"
+  - "6.0"
+  - "6.1"
+  - "6.2"
+os:
+  - linux
+  - centos
+  - macosx
+  - windows
 
 before_install:
   - travis_retry npm install -g npm@2.14.2

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ psTree(child.pid, function (err, children) {
 
 If you prefer to run **psTree** from the command line, use: `node ./bin/ps-tree.js`
 
+P.S. ps-tree also support Win32.
+
 [![Build Status](https://travis-ci.org/nelsonic/ps-tree.svg)](https://travis-ci.org/nelsonic/ps-tree)
 [![Code Climate](https://codeclimate.com/github/nelsonic/ps-tree/badges/gpa.svg)](https://codeclimate.com/github/nelsonic/ps-tree)
 [![Test Coverage](https://codeclimate.com/github/nelsonic/ps-tree/badges/coverage.svg)](https://codeclimate.com/github/nelsonic/ps-tree)

--- a/bin/ps-tree.js
+++ b/bin/ps-tree.js
@@ -2,6 +2,15 @@
 
 'use strict';
 
-require('../')(process.argv[2] || 1, function (err, data) {
+var ppid
+switch (process.platform) {
+  case 'win32':
+    ppid = 0
+    break;
+  default: // Linux
+    ppid = 1
+    break;
+}
+require('../')(process.argv[2] || ppid, function (err, data) {
   console.log(data);
 });

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ smss.exe                      4                228
       break;
     case 'darwin': // Mac TODO: Test and confirm
     default: // Linux
-      processLister = spawn('ps', ['-A', '-o', 'comm,ppid,pid,stat']);
+      processLister = spawn('ps', ['-A', '-o', 'ppid,pid,stat,comm']);
       break;
   }
 
@@ -54,12 +54,6 @@ smss.exe                      4                228
     processLister.stdout,
     es.split(),
     es.map(function (line, cb) { //this could parse alot of unix command output
-      /**
-       * XX Quick and dirty: ' <defunct> ' need to be striped under linux
-       * i.e. "watch <defunct>  1914 16964 Z"
-       */
-      line = line.replace(/ <defunct> /, '')
-
       var columns = line.trim().split(/\s+/);
       if (!headers) {
         headers = columns;

--- a/package.json
+++ b/package.json
@@ -12,21 +12,31 @@
   },
   "license": "MIT",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
+  "contributors": [
+    {
+      "name": "Zhuohuan LI",
+      "url": "https://github.com/zixia",
+      "email": "zixia@zixia.net"
+    }
+  ],
   "directories": {
     "test": "test"
   },
   "scripts": {
-    "test": "istanbul cover ./node_modules/.bin/tape ./test/test.js ./test/direct.js",
+    "_comment": "https://github.com/gotwarlost/istanbul#usage-on-windows",
+    "test": "istanbul cover node_modules/tape/bin/tape test/test.js test/direct.js",
     "coverage": "npm test && istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
-    "codeclimate": "CODECLIMATE_REPO_TOKEN=84436b4f13c70ace9c62e7f04928bf23c234eb212c0232d39d7fb1535beb2da5 ./node_modules/codeclimate-test-reporter/bin/codeclimate.js < ./coverage/lcov.info"
+    "codeclimate": "cross-env CODECLIMATE_REPO_TOKEN=84436b4f13c70ace9c62e7f04928bf23c234eb212c0232d39d7fb1535beb2da5 codeclimate < coverage/lcov.info"
   },
   "devDependencies": {
     "chalk": "^1.0.0",
     "codeclimate-test-reporter": "0.0.4",
+    "cross-env": "^1.0.8",
     "istanbul": "^0.3.20",
     "pre-commit": "0.0.9",
     "precommit": "^1.1.5",
-    "tape": "^3.0.3"
+    "tape": "^3.0.3",
+    "tree-kill": "^1.1.0"
   },
   "pre-commit": [
     "coverage",

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,8 @@ test(cyan('Spawn a Parent process which has a Two Child Processes'), function (t
       if (err) { console.log(err); }
       console.log(red('Children: '), children, '\n');
       t.true(children.length > 0, green('✓ There are ' + children.length + ' active child processes'));
-      cp.spawn('kill', ['-9'].concat(children.map(function (p) { return p.PID })))
+      // cp.spawn('kill', ['-9'].concat(children.map(function (p) { return p.PID })))
+      require('tree-kill')(parent.pid);
     });
 
     setTimeout(function () {
@@ -31,8 +32,9 @@ test(cyan('Spawn a Parent process which has a Two Child Processes'), function (t
         t.equal(children.length, 0, green('✓ No more active child processes (we killed them)'));
         t.end();
       });
-    }, 1000); // give psTree time to kill the processes
-  }, 200); // give the child process time to spawn
+    }, 2000); // give psTree time to kill the processes
+  }, 500); // give the child process time to spawn
+  // need more time on a slow(or heavy load server). maybe promise.then is better instead of the timeout
 });
 
 test(cyan('FORCE ERROR by calling psTree without supplying a Callback'), function (t) {
@@ -52,7 +54,8 @@ test(cyan('Spawn a Child Process and psTree with a String as pid'), function (t)
   setTimeout(function(){
     psTree(child.pid.toString(), function (err, children) {
       if (err) { console.log(err); }
-      cp.spawn('kill', ['-9'].concat(children.map(function (p) { return p.PID })))
+      // cp.spawn('kill', ['-9'].concat(children.map(function (p) { return p.PID })))
+      require('tree-kill')(child.pid);
     });
 
     setTimeout(function() {


### PR DESCRIPTION
@indexzero I had just finished a runable win32 version of ps-tree, include the following changes:

# Code:
1. use `wmic.exe` to simulate `ps` under win32 platform.
1. map output header of wmic to ps
1. strip the linux ` <defunct> ` from the output

# Test
1. modify `istanbul` command line to support win32
1. use npm module `tree-kill` to replace the `kill` to support win32
1. use npm module `cross-env` to enable set environment variable in package.json

Hope this helps. :)