### PR TITLE
Improve performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,12 +73,13 @@ module.exports = function childrenOfPid(pid, callback) {
       return cb(null, row);
     }),
     es.writeArray(function (err, ps) {
-      var parents = [pid],
+      var parents = {},
           children = [];
 
+      parents[pid] = true;
       ps.forEach(function (proc) {
-        if (parents.indexOf(proc.PPID) !== -1) {
-          parents.push(proc.PID)
+        if (parents[proc.PPID]) {
+          parents[proc.PID] = true;
           children.push(proc)
         }
       });


### PR DESCRIPTION
### Changes
The use of an array is not suited for the job. An hash set is far better.
This PR drastically reduces the complexity of the algorithm from **O(n^2)** to **O(n)**

@nelsonic @indexzero @zixia @soyuka