### PR TITLE
Improve CI configurations

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,41 +1,23 @@
-# http://www.appveyor.com/docs/appveyor-yml
-
-# Fix line endings in Windows. (runs before repo cloning)
-init:
-  - git config --global core.autocrlf true
-
-# Test against these versions of Node.js.
+build: off
+version: '{build}'
 environment:
   matrix:
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
-    - nodejs_version: "4.2"
-    - nodejs_version: "6.2"
-
-matrix:
-  allow_failures:
-    - nodejs_version: 0.10
-    - nodejs_version: 0.12
-
-# Install scripts. (runs after repo cloning)
+    - nodejs_version: '8'
+    - nodejs_version: '6'
+    - nodejs_version: '4'
+    - nodejs_version: '0.12'
+    - nodejs_version: '0.10'
+platform:
+  - x86
+  - x64
+cache:
+  - node_modules
 install:
-  - git rev-parse HEAD
-  # Get the latest stable version of Node 0.STABLE.latest
   - ps: Install-Product node $env:nodejs_version
-  # Typical npm stuff.
-  - md C:\nc
-  - npm config set cache C:\nc
-  - npm version
   - npm install
-
-# Post-install test scripts.
 test_script:
-  # Output useful info for debugging.
-  - npm version
-  - cmd: npm test
-
-# Don't actually build.
-build: off
-
-# Set build version format here instead of in the admin panel.
-version: "{build}"
+  - node --version
+  - npm --version
+  - npm test
+after_test:
+  - npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
+sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4.4"
-  - "6.2"
+  - '8'
+  - '6'
+  - '4'
+  - '0.12'
+  - '0.10'
 os:
   - linux
-  - centos
-  - macosx
-
-before_install:
-  - travis_retry npm install -g npm@2.14.2
-  - travis_retry npm install
-
+  - osx
+cache:
+  directories:
+  - node_modules
+install:
+  - npm install
 script:
+  - node --version
+  - npm --version
   - npm test
-
-matrix:
-  allow_failures:
-    - node_js: "0.10"
-    - node_js: "0.12"
+after_success:
+  - npm run coverage


### PR DESCRIPTION
## Changes
Test runs on the following node versions:
- '8'
- '6'
- '4'
- '0.12'
-  '0.10'

Note that we need to marge #27 to make this PR pass the CI checks.
This is because of the `coverage` script that is fixed inside #27.

cc @nelsonic @indexzero @zixia @soyuka