### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,24 @@
+name: ci-test
+on: [push, pull_request]
+
+jobs:
+
+  ps-tree-ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [18, 20, 22, 23]
+        os: [ubuntu-24.04, windows-2022, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - run: node -v
+      - run: npm -v
+      - name: Checkout
+        uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm test
+      - run: npm run coverage


### PR DESCRIPTION
- closes https://github.com/indexzero/ps-tree/issues/61

## Issue

Existing CI workflows are outdated and non-functional:

- [.travis.yml](https://github.com/indexzero/ps-tree/blob/master/.travis.yml)
- [.appveyor.yml](https://github.com/indexzero/ps-tree/blob/master/.appveyor.yml)

## Change

Add workflow [.github/workflows/ci-test.yml](https://github.com/MikeMcC399/ps-tree/blob/prime/.github/workflows/ci-test.yml)

- which triggers on `push` or `pull_request`

- runs on GitHub Actions latest runners `ubuntu-24.04`, `windows-2022` and `macos-14` using

- currently supported Node.js versions `18`, `20`, `22` and `23`

- and runs

  - `npm test`
  - `npm run coverage`